### PR TITLE
description of key 'group' for the Lfunctions collection. 

### DIFF
--- a/db-Lfunctions.md
+++ b/db-Lfunctions.md
@@ -553,6 +553,24 @@ Indexes for instances collection:
         </td>
         <td></td>
     </tr>
+    <tr>
+        <th>
+            Group             
+        </th>
+        <td>
+            the codomain group of the galois representation
+        </td>
+        <td>
+            string
+        </td>
+        <td>
+            u'GL2' or u'GL3' or u'GSp4'
+        </td>
+        <td>
+            Not every entry has this attribute
+        </td>
+    </tr>
+    
 </table>
 
 ### Lhash description


### PR DESCRIPTION
We were missing the description on key 'group' for the Lfunctions collection.  I added a possible description to the best of my knowledge.